### PR TITLE
Add Azure SQL support for Railway deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,27 +2,44 @@ FROM apache/superset:latest
 
 USER root
 
-RUN apt-get update && apt-get install -y \
-    pkg-config \
-    libmariadb-dev \
-    default-libmysqlclient-dev \
-    build-essential \
-    && rm -rf /var/lib/apt/lists/*
-    
-# Install PostgreSQL driver (no compilation needed)
-RUN pip install psycopg2-binary
+ARG DEBIAN_FRONTEND=noninteractive
 
-ENV ADMIN_USERNAME $ADMIN_USERNAME
-ENV ADMIN_EMAIL $ADMIN_EMAIL
-ENV ADMIN_PASSWORD $ADMIN_PASSWORD
-ENV DATABASE $DATABASE
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg2; \
+    . /etc/os-release; \
+    curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft-prod.gpg; \
+    curl "https://packages.microsoft.com/config/${ID}/${VERSION_ID}/prod.list" > /etc/apt/sources.list.d/mssql-release.list; \
+    apt-get update; \
+    ACCEPT_EULA=Y apt-get install -y --no-install-recommends \
+        msodbcsql18 \
+        unixodbc-dev \
+        pkg-config \
+        libmariadb-dev \
+        default-libmysqlclient-dev \
+        build-essential; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt
+
+ENV ADMIN_USERNAME=$ADMIN_USERNAME
+ENV ADMIN_EMAIL=$ADMIN_EMAIL
+ENV ADMIN_PASSWORD=$ADMIN_PASSWORD
+ENV DATABASE=$DATABASE
 
 COPY /config/superset_init.sh ./superset_init.sh
 RUN chmod +x ./superset_init.sh
 
 COPY /config/superset_config.py /app/
 ENV SUPERSET_CONFIG_PATH /app/superset_config.py
-ENV SECRET_KEY $SECRET_KEY
+ENV SECRET_KEY=$SECRET_KEY
 
 USER superset
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,53 @@
 # Apache Superset Docker for Railway
 
+This repository provides a Docker image that can be deployed directly to [Railway](https://railway.com/) to run [Apache Superset](https://superset.apache.org/).  It extends the official `apache/superset` image with:
 
-Modified code from here: https://medium.com/towards-data-engineering/quick-setup-configure-superset-with-docker-a5cca3992b28
+- automatic creation of the Superset admin user through environment variables (so no manual container exec is required);
+- database client libraries for PostgreSQL, MySQL/MariaDB and Microsoft SQL Server/Azure SQL;
+- a lightweight Superset configuration file that reads all secrets from the Railway environment.
 
-## Why this?
+> ℹ️  The Docker image now bundles Microsoft's ODBC Driver 18 together with `pyodbc`, which allows Superset to use **Azure SQL Database** as its metadata store or as a SQL Server datasource inside Superset.
 
-Apache Superset has Docker images for deployment but the setting of the admin user requires executing code in the container. That is not possible to set up in a Railway template. This modification supports the creation of the admin user through setting of environment variables.
+## Deploying on Railway
+
+1. Create a new Railway project and select “Deploy from GitHub repository”.
+2. Point Railway to this repository and trigger a deploy.
+3. Configure the following environment variables inside Railway:
+
+   | Variable | Purpose |
+   | --- | --- |
+   | `ADMIN_USERNAME` | Login for the Superset admin user. |
+   | `ADMIN_EMAIL` | Email address for the admin account. |
+   | `ADMIN_PASSWORD` | Password for the admin user. |
+   | `SECRET_KEY` | Flask secret key used by Superset. Generate a long random string. |
+   | `DATABASE` | SQLAlchemy connection string for Superset's metadata database. |
+
+   The entrypoint script fails fast when these variables are missing so you immediately know if something is misconfigured.
+
+4. Expose port `8088` (the default Superset web server port) in your Railway service settings.
+
+Once the deploy finishes Superset will be reachable using the Railway-generated URL. The admin user defined through the variables above will already be created.
+
+## Using Azure SQL as the metadata database
+
+Set the `DATABASE` environment variable to an Azure SQL SQLAlchemy URI that uses the bundled ODBC Driver 18.  A typical connection string looks like this:
+
+```
+mssql+pyodbc://<username>:<password>@<server>.database.windows.net:1433/<database>?driver=ODBC+Driver+18+for+SQL+Server&Encrypt=yes&TrustServerCertificate=no
+```
+
+- Replace `<username>`, `<password>`, `<server>` and `<database>` with your Azure SQL values.
+- URL-encode special characters in the password (for example `@` becomes `%40`).
+- Keep `Encrypt=yes` so the connection complies with Azure's security requirements.  Set `TrustServerCertificate=no` unless you have a specific reason to disable certificate validation.
+
+You can use the same URI format when defining Azure SQL datasets inside Superset.
+
+## Customising the image
+
+- Additional Python dependencies can be added to `requirements.txt`.
+- Further Superset configuration can be appended to `config/superset_config.py`.  The file already exposes the `DATABASE` and `SECRET_KEY` environment variables.
+- The startup sequence lives in `config/superset_init.sh`.  The script exits on errors to make debugging deployment issues easier.
+
+## Credits
+
+The base idea for automating the admin user creation is inspired by the article [Quick setup: Configure Superset with Docker](https://medium.com/towards-data-engineering/quick-setup-configure-superset-with-docker-a5cca3992b28).

--- a/config/superset_config.py
+++ b/config/superset_config.py
@@ -8,4 +8,4 @@ ENABLE_PROXY_FIX = True
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
-SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE")
+SQLALCHEMY_DATABASE_URI = os.environ["DATABASE"]

--- a/config/superset_init.sh
+++ b/config/superset_init.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # create Admin user, you can read these values from env or anywhere else possible
 superset fab create-admin --username "$ADMIN_USERNAME" --firstname Superset --lastname Admin --email "$ADMIN_EMAIL" --password "$ADMIN_PASSWORD"
@@ -7,7 +8,7 @@ superset fab create-admin --username "$ADMIN_USERNAME" --firstname Superset --la
 superset db upgrade
 
 # setup roles and permissions
-superset superset init 
+superset superset init
 
 # Starting server
 /bin/sh -c /usr/bin/run-server.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 psycopg2-binary
+pyodbc


### PR DESCRIPTION
## Summary
- install Microsoft's ODBC Driver 18 alongside other database client libraries so the image can talk to Azure SQL
- require Superset's DATABASE environment variable and harden the init script to fail fast when configuration is missing
- document the Railway deployment flow and how to format Azure SQL connection strings

## Testing
- not run (docker is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c94f3283548331a9da85384e4efbd4